### PR TITLE
Now KL_Update.bat is also an installer.

### DIFF
--- a/scripts/KL_Update.bat
+++ b/scripts/KL_Update.bat
@@ -2,12 +2,123 @@
 :: by Crowfunder
 :: my gh: https://github.com/Crowfunder
 :: KnightLauncher gh: https://github.com/lucas-allegri/KnightLauncher
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:: Checking if script was run inside Spiral Knights directory. If not, it asks for inputting game's main directory full path. Broken if somebody somehow has random "rsrc" and "scenes" folders in place where script is running. Too bad.
-IF EXIST rsrc IF EXIST scenes IF EXIST code\projectx-pcode.jar ( SET gamepath="%cd%" ) ELSE ( SET /P gamepath=Please enter Spiral Knights' directory absolute path: )
-CD "%gamepath%"
+:: gamepathfailsafe gets triggered once the script finds a suitable SK path.
+:: Later on, the script checks if it was triggered, if it was not - user is notified and prompted to manually enter the SK folder path.
+SET /A gamepathfailsafe=0
+SET regkeys[1]="HKEY_CURRENT_USER\SOFTWARE\Grey Havens\Spiral Knights"
+SET regkeys[2]="HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Valve\Steam"
+
+:: Check if the script is used inside the SK folder. If that's the case we skip whole game path detection.
+IF EXIST rsrc IF EXIST scenes IF EXIST code\projectx-pcode.jar ( 
+    SET gamepath="%cd%"
+    SET /A gamepathfailsafe=1
+    GOTO Install 
+    )
+
+:: Check if SK could've been installed anywhere. If not, prompt the user to manually enter the SK folder path and skip detection.
+:: Simply, per every "RegKey Not Found" error, the script increments the noflag counter, then it gets handled in manner:
+:: noflag = 0   User has to choose whether to install for Steam or for standalone.
+:: noflag = 1   Check which installation is present.
+:: noflag = 2   Prompt user to manually enter the SK folder path and skip detection.
+SET /A noflag=0
+setlocal enabledelayedexpansion
+FOR /L %%i in (1,1,2) do (
+    REG QUERY !regkeys[%%i]! >nul 2>&1!
+    IF !errorlevel! EQU 1 (
+        SET /A noflag=!noflag! + 1
+    )
+)
+:NoflagLoop
+IF !noflag! EQU 0 (
+    ECHO Where would you like your KnightLauncher installed? Pick a number.
+    ECHO 1 Steam
+    ECHO 2 Standalone
+    SET /P "installchoice=Your choice: "
+    IF "!installchoice!" EQU "1" (
+        GOTO SteamPath
+    )
+    IF "!installchoice!" EQU "2" (
+        rem
+    )
+    IF "!installchoice!" NEQ "1" IF "!installchoice!" NEQ "2" (
+        ECHO Wrong choice! Choose 1 or 2.
+        GOTO NoflagLoop
+    )
+)
+IF !noflag! EQU 2 (
+    GOTO Install
+)
+
+:: Check if it's standalone, if not, skip to SteamPath.
+REG QUERY %regkeys[1]% >nul 2>&1
+IF %errorlevel% EQU 1 (
+    SETLOCAL disabledelayedexpansion
+    GOTO SteamPath
+) ELSE (
+    FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY !regkeys[1]! /v INSTALL_DIR_REG_KEY`) DO (
+        SET gamepath="%%A %%B"
+        IF EXIST !gamepath! ( SET /A gamepathfailsafe=1 )
+    )
+    SETLOCAL disabledelayedexpansion
+    GOTO Install
+)
+
+
+:: Getting Steam Folder Path. We check if SK is installed in default Steam folder.
+:: Otherwise we parse libraryfolders.vdf file and check every other folder.
+:SteamPath
+FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY %regkeys[2]% /v InstallPath`) DO (
+    IF "%%B" EQU "" ( SET appdir=%%A) ELSE (
+        SET appdir=%%A %%B
+        )
+    )
+
+IF EXIST "%appdir%\steamapps\common\Spiral Knights" (
+    SET gamepath="%appdir%\steamapps\common\Spiral Knights"
+    SET /A gamepathfailsafe=1
+    GOTO Install
+    )
+SET listfile="%appdir%\steamapps\libraryfolders.vdf"
+
+
+:: If user has more than 9 steam library folders the script will commit die.
+:: I have no idea how to handle that.
+SET /A i=0
+SETLOCAL enabledelayedexpansion
+FOR /F "tokens=* skip=4 usebackq" %%a in (%listfile%) do (
+    IF /I "%%a" NEQ "}" IF /I "%%a" NEQ "" ( 
+        SET str="%%a"
+        SET str=!str:~7,-1!
+        SET /A i+=1
+        SET pathlist[!i!]=!str!
+      )
+)
+
+:: We check every steam dir
+SET /A Filesx=!i!
+FOR /L %%i in (1,1,!Filesx!) do (
+    IF EXIST "!pathlist[%%i]!\steamapps\common\Spiral Knights" (
+        SET gamepath="!pathlist[%%i]!\steamapps\common\Spiral Knights"
+    )
+) 
+SETLOCAL disabledelayedexpansion
+
+SET /A gamepathfailsafe=1
+
+:Install
+IF %gamepathfailsafe% EQU 0 (
+    ECHO Unable to find Spiral Knights' folder.
+    SET /P gamepath=Run the script inside it or please enter its path:   
+) 
+IF NOT EXIST %gamepath%\rsrc IF NOT EXIST %gamepath%\scenes IF NOT EXIST %gamepath%\code\projectx-pcode.jar (
+    SET /A gamepathfailsafe=0
+)
 
 :: Simple asking for confirmation, just in case.
+%gamepath:~1,2%
+CD "%gamepath%"
 ECHO KnightLauncher will be installed/updated in this folder: %gamepath%
 SET /P opt=Would you like to proceed? (Y/N) 
 IF /I %opt% EQU y ( SET buff=true )
@@ -15,10 +126,10 @@ IF /I %opt% EQU yes ( SET buff=true )
 IF /I %buff% NEQ true ( EXIT /b )
 
 :: Checking if other versions are installed, if there are - remove them retaining "KnightLauncher.properties".
+:: Also trying to kill the KnightLauncher process just in case.
 IF EXIST *KnightLauncher* ( 
     ECHO Detected other version installed, removing...
-    :: Trying to kill the KnightLauncher process just in case.
-    TASKKILL /IM javaw.exe
+    TASKKILL /IM javaw.exe >nul 2>&1!
     IF EXIST KnightLauncher.properties ( REN KnightLauncher.properties move.properties)
     DEL *KnightLauncher*
     IF EXIST move.properties ( REN move.properties KnightLauncher.properties )
@@ -41,6 +152,5 @@ DEL temp2
 
 :: Downloading and installing new version. NOTE: If "tar" fails - update to Windows 10, or update your Windows 10. Build 17063 at least.
 curl.exe %url% -o %filename% -L
-tar -xf %filename% 
-DEL %filename%
+tar -xf %filename%  & DEL %filename%
 ECHO Success!


### PR DESCRIPTION
**Changes:**
- KL_Update.bat is now capable of detecting Spiral Knight's path, ergo it can be ran from anywhere to update or install KnightLauncher to either standalone or Steam installation.
- Fixed script's inability to remove downloaded .zip
- TASKKILL will not return an error in case of KnightLauncher not running.

**Known Problems/Bugs:**
- If user has installed standalone and moved SK installation folder from it's default installation path, the script will be unable to detect SK installation path. As for now it's impossible to do anything about it.
- If user has more than 9 Steam game libraries the script will likely crash or return an error. I'm too lazy to fix it and I doubt that anyone using this script will have more than 9 Steam game libraries.