### PR TITLE
KL_Update.bat Hotfix

### DIFF
--- a/scripts/KL_Update.bat
+++ b/scripts/KL_Update.bat
@@ -4,21 +4,34 @@
 :: KnightLauncher gh: https://github.com/lucas-allegri/KnightLauncher
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:: gamepathfailsafe gets triggered once the script finds a suitable SK path.
-:: Later on, the script checks if it was triggered, if it was not - user is notified and prompted to manually enter the SK folder path.
-SET /A gamepathfailsafe=0
+:: Set Constant Vars
+:: I have no idea how to insert a var into cutting from string.
+:: For now "download_url" is purely informational.
 SET regkeys[1]="HKEY_CURRENT_USER\SOFTWARE\Grey Havens\Spiral Knights"
 SET regkeys[2]="HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Valve\Steam"
+SET api_url="https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest"
+SET download_url="https://github.com/lucas-allegri/KnightLauncher/releases/download/"
+SET javaurl="https://javadl.oracle.com/webapps/download/AutoDL?BundleId=245057_d3c52aa6bfa54d3ca74e617f18309292"
+SET javafname=jre_kl.exe
+SET separator=--------------------------------------------------------------------------------
 
-:: Check if the script is used inside the SK folder. If that's the case we skip whole game path detection.
+:: gamepathfailsafe gets triggered once the script finds a suitable SK path.
+:: Later on, the script checks if it was triggered. 
+:: If it was not - user is notified and prompted to manually enter the SK folder path.
+SET /A gamepathfailsafe=0
+
+:: Check if the script is used inside the SK folder. 
+:: If that's the case we skip whole game path detection.
 IF EXIST rsrc IF EXIST scenes IF EXIST code\projectx-pcode.jar ( 
     SET gamepath="%cd%"
     SET /A gamepathfailsafe=1
     GOTO Install 
     )
 
-:: Check if SK could've been installed anywhere. If not, prompt the user to manually enter the SK folder path and skip detection.
-:: Simply, per every "RegKey Not Found" error, the script increments the noflag counter, then it gets handled in manner:
+:: Check if SK could've been installed anywhere. 
+:: If not, prompt the user to manually enter the SK folder path and skip detection.
+:: Simply, per every "RegKey Not Found" error, the script increments the noflag counter.
+:: It gets handled in manner:
 :: noflag = 0   User has to choose whether to install for Steam or for standalone.
 :: noflag = 1   Check which installation is present.
 :: noflag = 2   Prompt user to manually enter the SK folder path and skip detection.
@@ -112,8 +125,12 @@ IF %gamepathfailsafe% EQU 0 (
     ECHO Unable to find Spiral Knights' folder.
     SET /P gamepath=Run the script inside it or please enter its path:   
 ) 
-IF NOT EXIST %gamepath%\rsrc IF NOT EXIST %gamepath%\scenes IF NOT EXIST %gamepath%\code\projectx-pcode.jar (
-    SET /A gamepathfailsafe=0
+IF NOT EXIST %gamepath%\rsrc ( 
+	IF NOT EXIST %gamepath%\scenes (
+		IF NOT EXIST %gamepath%\code\projectx-pcode.jar (
+    		SET /A gamepathfailsafe=0
+    	)	
+    )		
 )
 
 :: Simple asking for confirmation, just in case.
@@ -131,21 +148,23 @@ SETLOCAL EnableDelayedExpansion
 javaw >nul 2>&1!
 IF "%errorlevel%" EQU "9009" (
     ECHO You need Java installed on your machine to use KnightLauncher.
-    ECHO Downloading...
-    SET javafname=jre_kl.exe
-    SET javaurl="https://javadl.oracle.com/webapps/download/AutoDL?BundleId=245058_d3c52aa6bfa54d3ca74e617f18309292"
-    ECHO --------------------------------------------------------------------------------
-    curl.exe !javaurl! -o !javafname! -L
-    ECHO --------------------------------------------------------------------------------
-    ECHO Success. Please proceed with the installation. The script will restart itself.
+	IF NOT EXIST jre_kl.exe (
+		ECHO Downloading...
+		ECHO %separator%
+		curl.exe !javaurl! -o !javafname! -L
+		ECHO %separator%
+		ECHO Success. 
+	)
+    ECHO Please proceed with the installation. The script will restart itself afterwards.
     PING -n 4 127.0.0.1>nul
     !javafname!
-    DEL !javafname!
     START KL_Update.bat & EXIT
 )
+DEL !javafname!
 SETLOCAL DisableDelayedExpansion
 
-:: Checking if other versions are installed, if there are - remove them retaining "KnightLauncher.properties".
+:: Checking if other versions are installed.
+:: If there are - remove them retaining "KnightLauncher.properties".
 :: Also trying to kill the KnightLauncher process just in case.
 IF EXIST *KnightLauncher* ( 
     ECHO Detected other version installed, removing...
@@ -158,7 +177,7 @@ IF EXIST *KnightLauncher* (
 
 :: Preparing installation info.
 ECHO Downloading...
-curl.exe -sSL https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest | findstr browser_download_url > temp 
+curl.exe -sSL %api_url% | findstr browser_download_url > temp 
 SET /P url=<temp
 DEL temp
 SET url=%url:"=%
@@ -172,9 +191,8 @@ DEL temp2
 
 :: Downloading, installing and running the new version.
 :: NOTE: If "tar" fails - update to Windows 10, or update your Windows 10. Build 17063 at least.
-ECHO --------------------------------------------------------------------------------
+ECHO %separator%
 curl.exe %url% -o %filename% -L
-ECHO --------------------------------------------------------------------------------
-tar -xf %filename%  & DEL %filename%
+ECHO %separator%
+tar -xf %filename% & DEL %filename% & KnightLauncher_windows.bat
 ECHO Success!
-KnightLauncher_windows.bat

--- a/scripts/KL_Update.bat
+++ b/scripts/KL_Update.bat
@@ -118,6 +118,7 @@ IF NOT EXIST %gamepath%\rsrc IF NOT EXIST %gamepath%\scenes IF NOT EXIST %gamepa
 
 :: Simple asking for confirmation, just in case.
 %gamepath:~1,2%
+SET buff=false
 CD "%gamepath%"
 ECHO KnightLauncher will be installed/updated in this folder: %gamepath%
 SET /P opt=Would you like to proceed? (Y/N) 
@@ -127,20 +128,20 @@ IF /I %buff% NEQ true ( EXIT /b )
 
 :: Check if Java is properly installed. Download and install if it's not.
 SETLOCAL EnableDelayedExpansion
-:JavaCheck
 javaw >nul 2>&1!
 IF "%errorlevel%" EQU "9009" (
     ECHO You need Java installed on your machine to use KnightLauncher.
     ECHO Downloading...
     SET javafname=jre_kl.exe
-    SET javaurl="https://javadl.oracle.com/webapps/download/AutoDL?BundleId=245057_d3c52aa6bfa54d3ca74e617f18309292"
+    SET javaurl="https://javadl.oracle.com/webapps/download/AutoDL?BundleId=245058_d3c52aa6bfa54d3ca74e617f18309292"
     ECHO --------------------------------------------------------------------------------
     curl.exe !javaurl! -o !javafname! -L
     ECHO --------------------------------------------------------------------------------
-    ECHO Success. Please proceed with the installation.
+    ECHO Success. Please proceed with the installation. The script will restart itself.
+    PING -n 4 127.0.0.1>nul
     !javafname!
     DEL !javafname!
-    GOTO JavaCheck
+    START KL_Update.bat & EXIT
 )
 SETLOCAL DisableDelayedExpansion
 


### PR DESCRIPTION
- **Fixed Java downloader, it will now restart the entire script instead of looping.**
_Apparently batch requires a hard restart to refresh path variables. Looping did not detect, that the user had actually installed Java using the script and so it looped forever._ 
- <s>**The script now uses the offline Java 64bit installer instead of online.**
_It's an experiment of sorts. While the online installer detects the OS version automatically, the offline installer is more reliable. It may be necessary to add OS version detection to the script itself, in case somehow some users still have Win 32bit. Otherwise it's possible to simply roll back to the online installer._</s>
I've decided that this change makes little to no sense, in case something gets reported about this thing I'll gladly use the offline installer. 
- **Cleaned up the code a bit.**
*Basically, moved all the constant vars to the top and cut some long code lines short.*
- **Java downloader will now check if the installer had been downloaded already.**
*It's to prevent multiple redownloads in case user or sth else interrupts the installation and the script iterates through another loop.*